### PR TITLE
Fix the keyboard assignment

### DIFF
--- a/src/menues.c
+++ b/src/menues.c
@@ -2624,9 +2624,9 @@ if (!VOLUMEALL) {
             } else {
                 sound(PISTOL_BODYHIT);
 
-                KeyboardKeys[function][whichkey] = KB_GetLastScanCode();
+                KeyboardKeys[function][whichkey] = sc;
                 if (function == gamefunc_Show_Console)
-                    OSD_CaptureKey(KB_GetLastScanCode());
+                    OSD_CaptureKey(sc);
                 else
                     CONTROL_MapKey( function, KeyboardKeys[function][0], KeyboardKeys[function][1] );
             }


### PR DESCRIPTION
Since the recent change to KB_GetLastScanCode assigning functions the keys didn't work, as it was called multiple times.